### PR TITLE
Update linkbutton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [16.x]
 
     steps:
       - name: Checkout Code

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "nx": "16.7.0",
     "prettier": "^2.6.2",
     "react-refresh": "^0.10.0",
+    "react-router-dom": "^6.15.0",
     "sass": "^1.65.1",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",
@@ -66,7 +67,9 @@
     "clsx": "^2.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.15.0",
     "tslib": "^2.3.0"
+  }, 
+  "peerDependencies": {
+    "react-router-dom": ">=5.0.0"
   }
 }

--- a/packages/ui/src/lib/Button/LinkButton.tsx
+++ b/packages/ui/src/lib/Button/LinkButton.tsx
@@ -1,19 +1,25 @@
-import React, { forwardRef } from "react";
-import { Link } from "react-router-dom";
-import { ButtonVariant } from "./Button";
-import cx from "clsx";
-import styles from "./styles.module.scss";
+import React, { AnchorHTMLAttributes, forwardRef, ReactElement, RefAttributes } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { ButtonVariant } from './Button';
+import cx from 'clsx';
+import styles from './styles.module.scss';
 
 export type LinkButtonProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   /** Defaults to 'primary' */
   variant?: ButtonVariant;
   /** sets width to 100% */
-  fullWidth?: boolean;
+  fullwidth?: boolean;
   /** increase font-size and padding */
   large?: boolean;
   /** if it is React Link the route to load */
   to?: string;
 };
+
+export type RoutedLinkProps = LinkProps & LinkButtonProps;
+
+export type AnchorButtonProps = AnchorHTMLAttributes<HTMLAnchorElement> & LinkButtonProps;
+
+type PolymorphicProps = AnchorButtonProps & RoutedLinkProps;
 
 /**
  * Anchor styled as Clover button.
@@ -53,51 +59,30 @@ export type LinkButtonProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
     Link button
 </LinkButton>
  */
-export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
-  (
-    {
-      variant = "primary",
-      fullWidth,
-      large,
-      className,
-      children,
-      href,
-      to,
-      ...passThroughProps
-    },
-    ref
-  ) => {
-    const isLink = href !== undefined && !to;
-    return isLink ? (
-      <a
-        ref={ref}
-        className={cx(
-          styles.button,
-          styles[variant],
-          fullWidth && styles.fullwidth,
-          large && styles.large,
-          className
-        )}
-        href={href}
-        {...passThroughProps}
-      >
+
+export const LinkButtonImpl = forwardRef<HTMLAnchorElement, PolymorphicProps>(
+  ({ variant = 'primary', fullwidth, large, className, children, ...passThroughProps }, ref) => {
+    const Component = 'href' in passThroughProps ? 'a' : Link;
+
+    const classNames = cx(
+      styles.button,
+      styles[variant],
+      fullwidth && styles.fullwidth,
+      large && styles.large,
+      className
+    );
+
+    return (
+      <Component className={classNames} {...passThroughProps} ref={ref}>
         {children}
-      </a>
-    ) : (
-      <Link
-        ref={ref}
-        to={to ?? ""}
-        className={cx(
-          styles.button,
-          styles[variant],
-          fullWidth && styles.fullwidth,
-          large && styles.large,
-          className
-        )}
-        {...passThroughProps}
-      >
-        {children}
-      </Link>
+      </Component>
     );
   }
 );
+
+export type LinkButtonType = typeof LinkButtonImpl & {
+  (props: AnchorButtonProps & RefAttributes<HTMLAnchorElement>): ReactElement | null;
+  (props: LinkButtonProps & RefAttributes<HTMLAnchorElement>): ReactElement | null;
+};
+
+export const LinkButton = LinkButtonImpl as LinkButtonType;


### PR DESCRIPTION
I don't have fancy AI, so here goes:
They made some updates to fix the type probs that you already addressed `LinkButton`. 
I still updated so it will be reflective, but I'm sure your fix is better.

There were some issues with our current lib creating some probs because some of the microfrontends are using really old versions of `react-router-dom` so I changed package.json to reflect the fix that we made to our current lib.

Recently, when I updated our Jenkins node instance in the current prod lib, infra people had to roll it back to 16. I know they are working on whatever issues they're having that necessitated that rollback, but for now I just changed it to be like what is working in Clover rn. 

Lmk if this makes sense . 